### PR TITLE
Fix automatic link summary for textless links in glossary

### DIFF
--- a/AdLerDokumentation/Writerside/topics/AdLer-Projekt-GE.md
+++ b/AdLerDokumentation/Writerside/topics/AdLer-Projekt-GE.md
@@ -20,7 +20,7 @@
     </tr>
     <tr>
         <td>Definition</td>
-        <td id="summary">Das AdLer-Projekt ist das Projekt, in dem das <a href="AdLer-System.md"></a> entwickelt wird.</td>
+        <td id="summary">Das AdLer-Projekt ist das Projekt, in dem das <a href="AdLer-System.md">AdLer-System</a> entwickelt wird.</td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/AdLer-System-GE.md
+++ b/AdLerDokumentation/Writerside/topics/AdLer-System-GE.md
@@ -20,14 +20,14 @@
     </tr>
     <tr>
         <td>Definition</td>
-        <td id="summary">Im <a href="AdLer-Projekt-GE.md"></a> ist das AdLer-System das Softwaresystem,
+        <td id="summary">Im <a href="AdLer-Projekt-GE.md">AdLer-Projekt</a> ist das AdLer-System das Softwaresystem,
             welches sich aus den folgenden <a href="Betrachtungsgegenstand-GE.md">Betrachtungsgegenständen</a> 
             zusammensetzt:
-            <a href="Autorentool-BG.md"></a>, 
-            <a href="Engine-BG.md"></a>,
-            <a href="Plugin-BG.md"></a>
+            <a href="Autorentool-BG.md">Autorentool</a>, 
+            <a href="Engine-BG.md">Engine</a>,
+            <a href="Plugin-BG.md">Plugin</a>
             und 
-            <a href="Backend-BG.md"></a>.</td>
+            <a href="Backend-BG.md">Backend</a>.</td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Adaptivitätselement-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Adaptivitätselement-GE.md
@@ -20,7 +20,7 @@
     </tr>
     <tr>
         <td>Definition</td>
-        <td id="summary" >Ein Adaptivitätselement ist ein <a href="Lernelement-GE.md"></a>, welches <a href="Adaptivitätsaufgabe-GE.md">Adaptivitätsaufgaben</a>, <a href="Adaptivitätsfrage-GE.md">Adaptivitätsfragen</a> und <a href="Adaptivitätshinweis-GE.md">Adaptivitätshinweise</a> beinhaltet. </td>
+        <td id="summary" >Ein Adaptivitätselement ist ein <a href="Lernelement-GE.md">Lernelement</a>, welches <a href="Adaptivitätsaufgabe-GE.md">Adaptivitätsaufgaben</a>, <a href="Adaptivitätsfrage-GE.md">Adaptivitätsfragen</a> und <a href="Adaptivitätshinweis-GE.md">Adaptivitätshinweise</a> beinhaltet. </td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Adaptivitätsfrage-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Adaptivitätsfrage-GE.md
@@ -21,7 +21,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >Eine Adaptivitätsfrage ist eine Single- oder Multiple-Choice Frage. Sie ist immer einer von drei Schwierigkeitsstufen (leicht, mittel, schwer) zugeordnet.
-        Einer Adaptivitätsfrage kann ein <a href="Adaptivitätshinweis-GE.md"></a> zugeordnet sein.</td>
+        Einer Adaptivitätsfrage kann ein <a href="Adaptivitätshinweis-GE.md">Adaptivitätshinweis</a> zugeordnet sein.</td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Adaptivitätshinweis-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Adaptivitätshinweis-GE.md
@@ -20,7 +20,7 @@
     </tr>
     <tr>
         <td>Definition</td>
-        <td id="summary" >Ein Adaptivitätshinweis ist ein kurzer optionaler Hinweistext mit einem optionalen Verweis auf ein anderes <a href="Lernelement-GE.md"></a>, der dem Lernenden bei der weiteren Bearbeitung einer falsch beantworteten <a href="Adaptivitätsfrage-GE.md"></a> helfen soll.</td>
+        <td id="summary" >Ein Adaptivitätshinweis ist ein kurzer optionaler Hinweistext mit einem optionalen Verweis auf ein anderes <a href="Lernelement-GE.md">Lernelement</a>, der dem Lernenden bei der weiteren Bearbeitung einer falsch beantworteten <a href="Adaptivitätsfrage-GE.md">Adaptivitätsfrage</a> helfen soll.</td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Administrierende-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Administrierende-GE.md
@@ -21,7 +21,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary">Administrierende sind die Benutzenden ,
-            die das <a href="AdLer-System.md"></a>
+            die das <a href="AdLer-System.md">AdLer-System</a>
             in Betrieb nehmen und verwalten.</td>
     </tr>  
     <tr>

--- a/AdLerDokumentation/Writerside/topics/Autorentool-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Autorentool-GE.md
@@ -20,9 +20,9 @@
     </tr>
     <tr>
         <td>Definition</td>
-        <td id="summary" >Der <a href="Betrachtungsgegenstand-GE.md"></a> <a href="Autorentool-BG.md"></a> 
+        <td id="summary" >Der <a href="Betrachtungsgegenstand-GE.md">Betrachtungsgegenstand</a> <a href="Autorentool-BG.md">Autorentool</a> 
             des <a href="AdLer-System-GE.md">AdLer-Systems</a> bildet zusammen
-            mit dem <a href="Generator-GE.md"></a>  das Tool, 
+            mit dem <a href="Generator-GE.md">Generator</a> das Tool, 
             mit dem Lehrende Kurse für das AdLer-System erstellen können. 
             Das Tool soll dabei unter anderem die Möglichkeit bieten, neue Kurse als Lernwelten anzulegen, 
             in diesen Lernelemente mittels Lernräumen zu organisieren und diese mit Lernpfaden zu verknüpfen. 

--- a/AdLerDokumentation/Writerside/topics/Avatar-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Avatar-GE.md
@@ -22,7 +22,7 @@
         <td>Definition</td>
         <td id="summary">
             Der Avatar ist die 3D-Repräsentation des <a href="Lernende-GE.md">Lernenden</a> 
-            in den begehbaren <a href="Lernraum-GE.md">Lernräumen</a> der <a href="Engine-GE.md"></a>.
+            in den begehbaren <a href="Lernraum-GE.md">Lernräumen</a> der <a href="Engine-GE.md">Engine</a>.
         </td>
     </tr>  
     <tr>

--- a/AdLerDokumentation/Writerside/topics/Avatar-in-Spielen-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Avatar-in-Spielen-GE.md
@@ -32,7 +32,7 @@
     </tr>  
     <tr>
         <td>Siehe auch</td>
-        <td><a href="Avatar-GE.md" </td>
+        <td><a href="Avatar-GE.md"/></td>
     </tr>
     <tr>
         <td>Akronym</td>

--- a/AdLerDokumentation/Writerside/topics/Avatar-in-Spielen-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Avatar-in-Spielen-GE.md
@@ -32,7 +32,7 @@
     </tr>  
     <tr>
         <td>Siehe auch</td>
-        <td><a href="Avatar-GE.md"/> </td>
+        <td><a href="Avatar-GE.md" </td>
     </tr>
     <tr>
         <td>Akronym</td>

--- a/AdLerDokumentation/Writerside/topics/Backend-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Backend-GE.md
@@ -23,7 +23,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary">Das Backend bezeichnet den Teil einer Software, der nicht direkt vom Endnutzer interagiert wird. Es umfasst Server, Datenbanken und die serverseitige Logik, die Datenverarbeitung, Speicherung und die Kommunikation zwischen dem Frontend und der Datenbank steuert.
-    Bei AdLer steuert das Backend die Kommunikation zum und vom <a href="Autorentool-GE.md"></a>, dient als die einzige Schnittstelle für die <a href="Engine-GE.md"></a> und übernimmt die Kommunikation mit dem <a href="Learning-Management-System-GE.md"></a>.
+    Bei AdLer steuert das Backend die Kommunikation zum und vom <a href="Autorentool-GE.md">Autorentool</a>, dient als die einzige Schnittstelle für die <a href="Engine-GE.md">Engine</a> und übernimmt die Kommunikation mit dem <a href="Learning-Management-System-GE.md">Learning Management System</a>.
 </td>
     </tr>  
     <tr>

--- a/AdLerDokumentation/Writerside/topics/Benutzerdokumentation-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Benutzerdokumentation-GE.md
@@ -21,8 +21,8 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >Die Benutzerdokumentation ist die
-            detaillierte Dokumentation für die <a href="Endanwender-GE.md"></a>,
-            die das <a href="AdLer-System-GE.md"></a> im laufenden Betrieb verwenden sein. 
+            detaillierte Dokumentation für die <a href="Endanwender-GE.md">Endanwender</a>,
+            die das <a href="AdLer-System-GE.md">AdLer-System</a> im laufenden Betrieb verwenden sein. 
             Niedrigste Vorkenntnisse müssen vorausgesetzt werden. 
             Hierbei ist der Dümmste Anzunehmende Benutzer (DAB) zu berücksichtigen.
             Der Detaillierungsgrad ist eine Schritt-für-Schritt-Anleitung auf 

--- a/AdLerDokumentation/Writerside/topics/Endanwender-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Endanwender-GE.md
@@ -22,8 +22,8 @@
         <td>Definition</td>
         <td id="summary" >Endanwender sind die Anwender, 
         die das AdLer-System im Betrieb verwenden:
-        <a href="Lehrende-GE.md"></a>
-        <a href="Lernende-GE.md"></a></td>
+        <a href="Lehrende-GE.md">Lehrende</a>,
+        <a href="Lernende-GE.md">Lernende</a></td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Entwickelnde-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Entwickelnde-GE.md
@@ -21,7 +21,7 @@
         <td>Definition</td>
         <td id="summary" >
             Entwickelnde sind die Personen, 
-            die das <a href="AdLer-System.md"></a> 
+            die das <a href="AdLer-System.md">AdLer-System</a> 
             entwickeln. Unter anderem werden von diesen die folgenden Artefakte
             entwickelt: Assets, Tests, Icons, Code, Dokumentation, Architektur,
             Software Design, GUI-Design, Anforderungen, Leitfäden, CI-CD-Pipeline, usw. 

--- a/AdLerDokumentation/Writerside/topics/Externes-Lernelement-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Externes-Lernelement-GE.md
@@ -21,7 +21,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >
-            Ein externes Lernelement ist ein <a href="Lernelement-GE.md">Lernelement</a> welches <a href="Lernmaterial-GE.md"></a> beinhaltet und 
+            Ein externes Lernelement ist ein <a href="Lernelement-GE.md">Lernelement</a> welches <a href="Lernmaterial-GE.md">Lernmaterial</a> beinhaltet und 
             im Kontext eines <a href="Adaptivitätsaufgabe-GE.md">Adaptivitätselements</a> als <a href="Adaptivitätshinweis-GE.md">Hinweis</a> angezeigt wird.
         </td>
     </tr>  

--- a/AdLerDokumentation/Writerside/topics/Generator-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Generator-GE.md
@@ -20,8 +20,8 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >
-            Der <a href="Betrachtungsgegenstand-GE.md"></a>
-            <a href="Generator-BG.md"></a> 
+            Der <a href="Betrachtungsgegenstand-GE.md">Betrachtungsgegenstand</a>
+            <a href="Generator-BG.md">Generator</a> 
             des <a href="AdLer-System-GE.md">AdLer-Systems</a> 
             ist für die Generierung 
             der immersiven 3D Lernwelten zuständig.</td>

--- a/AdLerDokumentation/Writerside/topics/Lernelement-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Lernelement-GE.md
@@ -21,7 +21,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >
-            Ein Lernelement ist ein Element eines <a href="Lernraum-GE.md">Lernraums</a>, welches einen <a href="Lernmaterial-GE.md"></a>
+            Ein Lernelement ist ein Element eines <a href="Lernraum-GE.md">Lernraums</a>, welches einen <a href="Lernmaterial-GE.md">Lernmaterial</a>
             und Metadaten wie Punkte, Arbeitsaufwand, Schwierigkeitsgrad, 3D-Darstellung, Lernziele und Beschreibung 
             beinhaltet.
         </td>

--- a/AdLerDokumentation/Writerside/topics/Lernmaterial-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Lernmaterial-GE.md
@@ -22,7 +22,7 @@
         <td>Definition</td>
         <td id="summary" >
             Ein Lerninhalt ist der eigentliche Inhalt eines <a href="Lernelement-GE.md">Lernelements</a>, welcher einem
-            <a href="Lernende-GE.md">Lernenden</a> in der <a href="Engine-GE.md"></a> angezeigt wird. Es kann sich dabei
+            <a href="Lernende-GE.md">Lernenden</a> in der <a href="Engine-GE.md">Engine</a> angezeigt wird. Es kann sich dabei
             sowohl um rein belehrende Inhalte (Bilder, Videos), Wissen abfragende Inhalte (Quizzes), spielerische Inhalte
             (Schiebepuzzle, Word-Search) oder um Kombinationen all dieser Kategorien von Inhalten handeln.<br/>
         </td>

--- a/AdLerDokumentation/Writerside/topics/Lernraum-Template-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Lernraum-Template-GE.md
@@ -20,7 +20,7 @@
     </tr>
     <tr>
         <td>Definition</td>
-        <td id="summary" >Eine Lernraum Template definiert den räumlichen Aufbau eines Lernraumes in der 3D-Lernumgebung. Dazu gehören u.A. die Eckpunkte des Räumes, Positionen/Rotation von Fenstern und Türen, und Position/Rotation der <a href="Lernelement-Slot-GE.md">Lernelement Slots</a>.</td>
+        <td id="summary" >Ein Lernraum Template definiert den räumlichen Aufbau eines Lernraumes in der 3D-Lernumgebung. Dazu gehören u.A. die Eckpunkte des Räumes, Positionen/Rotation von Fenstern und Türen, und Position/Rotation der <a href="Lernelement-Slot-GE.md">Lernelement Slots</a>.</td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Nicht-Primitives-Lernelement-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Nicht-Primitives-Lernelement-GE.md
@@ -21,7 +21,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >Nicht-primitive Lernelemente sind Lernelemente mit intrisischer Punktevergabelogik. Das heißt die Punktevergabelogik des Lernelements wird in AdLer miteinbezogen und es kann auch zur Wissensabfrage verwendet werden.
-        Beispiele für nicht-primitive Lernelemente sind manche <a href="H5P-GE.md">H5P</a>-Lernelement und das <a href="Adaptivitätselement-GE.md"></a></td>
+        Beispiele für nicht-primitive Lernelemente sind manche <a href="H5P-GE.md">H5P</a>-Lernelement und das <a href="Adaptivitätselement-GE.md">Adaptivitätselement</a>.</td>
     </tr>  
     <tr>
         <td>Siehe auch</td>

--- a/AdLerDokumentation/Writerside/topics/Storyelement-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Storyelement-GE.md
@@ -28,8 +28,8 @@
             In verschiedenen Medien wie Literatur, Film und Videospielen sind Storyelemente entscheidend, 
             um das Interesse und die emotionale Bindung des Publikums zu fördern. 
             Ein gut durchdachtes Storyelement kann die Tiefe und Komplexität einer Geschichte erheblich bereichern.<br/>
-            Im AdLer System handelt es sich bei einem Storyelement um ein spezielles <a href="Lernelement-GE.md"></a>, welches kein
-            <a href="Lernmaterial-GE.md"></a> beinhaltet, sondern stattdessen Texte enthält, die den 
+            Im AdLer System handelt es sich bei einem Storyelement um ein spezielles <a href="Lernelement-GE.md">Lernelement</a>, welches kein
+            <a href="Lernmaterial-GE.md">Lernmaterial</a> beinhaltet, sondern stattdessen Texte enthält, die den 
             <a href="Lernende-GE.md">Lernenden</a> entweder bei Betreten oder Verlassen eines 
             <a href="Lernraum-GE.md">Lernraums</a> angezeigt werden. Mittels dieser Elemente soll 
             <a href="Lehrende-GE.md">Lehrenden</a> ermöglicht werden, spielerisch eine Story zu erzählen.<br/>

--- a/AdLerDokumentation/Writerside/topics/Technische-Dokumentation-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Technische-Dokumentation-GE.md
@@ -22,14 +22,14 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >
-            Die technische Dokumentation ist die <a href="Dokumentation-GE.md"></a>,
-            welche genutzt werden kann, um das <a href="AdLer-System.md"></a> zu entwickeln, 
+            Die technische Dokumentation ist die <a href="Dokumentation-GE.md">Dokumentation</a>,
+            welche genutzt werden kann, um das <a href="AdLer-System.md">AdLer-System</a> zu entwickeln, 
             in Betrieb zu nehmen und zu betreiben. 
             Beispiele: 
             Installationsanleitung, 
-            <a href="Wartungsdokumentation-GE.md"></a> , 
-            <a href="Testdokumentation-GE.md"></a> , 
-            <a href="Spezifikation-GE.md"></a> , 
+            <a href="Wartungsdokumentation-GE.md">Wartungsdokumentation</a> , 
+            <a href="Testdokumentation-GE.md">Testdokumentation</a> , 
+            <a href="Spezifikation-GE.md">Spezifikation</a> , 
         </td>
     </tr>  
     <tr>

--- a/AdLerDokumentation/Writerside/topics/Testdokumentation-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Testdokumentation-GE.md
@@ -22,7 +22,7 @@
     <tr>
         <td>Definition</td>
         <td id="summary" >
-            Die Testdokumentation ist die <a href="Dokumentation-GE.md"></a>, 
+            Die Testdokumentation ist die <a href="Dokumentation-GE.md">Dokumentation</a>, 
             die zum Testen des <a href="AdLer-System.md">AdLer-Systems</a>
             erforderlich ist.
         </td>

--- a/AdLerDokumentation/Writerside/topics/Wartungsdokumentation-GE.md
+++ b/AdLerDokumentation/Writerside/topics/Wartungsdokumentation-GE.md
@@ -24,7 +24,7 @@
         <td>Definition</td>
         <td id="summary" >
             Die Wartungsdokumentation ist
-            die <a href="Dokumentation-GE.md"></a>, die zum Betreiben 
+            die <a href="Dokumentation-GE.md">Dokumentation</a>, die zum Betreiben 
             des <a href="AdLer-System.md">Adler-Systems</a> erforderlich ist.
         </td>
     </tr>  


### PR DESCRIPTION
Textless links will not be resolved for link summaries, thus we need to add a text to it to display correctly.